### PR TITLE
Fix IPFS base URL

### DIFF
--- a/download_genbank_datasets.py
+++ b/download_genbank_datasets.py
@@ -43,7 +43,7 @@ def get_genbank_file(url, outFile):
     r.close()
 
 def download_ipfs(genome_path, outF, ipfs_api, failed):
-    ipfs_url = "/ipfs/zDMZof1m4BD9VvDjPqguMrAoiY2gspmSAyyNLNYxNxRntLdXK3wj"
+    ipfs_url = "/ipns/genbank.oxli.org"
     url = os.path.join(ipfs_url, genome_path)
     print(url)
     with open(outF, 'wb') as f:


### PR DESCRIPTION
So, you know, this works now =]

(I set a DNS TXT record at `genbank.oxli.org` that lets IPFS resolve to the most updated hash I have for the genbank mirror).

Caveat: this is still using the directory tree `ncbi-genome-download`creates, I have a mirror with the original NCBI structure but it will take 10 days to add to IPFS 😿